### PR TITLE
Remove gif usage, modernize

### DIFF
--- a/statsbestmanufacturers.php
+++ b/statsbestmanufacturers.php
@@ -98,17 +98,17 @@ class statsbestmanufacturers extends ModuleGrid
             'pagingMessage' => $this->paging_message,
         ];
 
-        if (Tools::getValue('export')) {
+        if (Tools::getValue('export') == 1) {
             $this->csvExport($engine_params);
         }
-
         $this->html = '
-		<fieldset>
-			<legend><img alt="' . $this->name . '" src="../modules/' . $this->name . '/logo.gif" /> ' . $this->displayName . '</legend>
-			' . $this->engine($engine_params) . '<br />
-			<a href="' . Tools::safeOutput($_SERVER['REQUEST_URI'] . '&export=1') . '"><img alt="asterisk" src="../img/admin/asterisk.gif" />' . $this->trans('CSV Export', [], 'Admin.Global') . '</a>
-		</fieldset>
-		';
+			<div class="panel-heading">
+				' . $this->displayName . '
+			</div>
+			' . $this->engine($engine_params) . '
+			<a class="btn btn-default export-csv" href="' . Tools::safeOutput($_SERVER['REQUEST_URI'] . '&export=1') . '">
+				<i class="icon-cloud-upload"></i> ' . $this->trans('CSV Export', [], 'Admin.Global') . '
+			</a>';
 
         return $this->html;
     }

--- a/statsbestmanufacturers.php
+++ b/statsbestmanufacturers.php
@@ -57,7 +57,7 @@ class statsbestmanufacturers extends ModuleGrid
                 'id' => 'name',
                 'header' => $this->trans('Name', [], 'Admin.Global'),
                 'dataIndex' => 'name',
-                'align' => 'left',
+                'align' => 'center',
                 'width' => 200,
             ],
             [
@@ -65,14 +65,14 @@ class statsbestmanufacturers extends ModuleGrid
                 'header' => $this->trans('Quantity sold', [], 'Admin.Global'),
                 'dataIndex' => 'quantity',
                 'width' => 60,
-                'align' => 'right',
+                'align' => 'center',
             ],
             [
                 'id' => 'sales',
                 'header' => $this->trans('Total paid', [], 'Modules.Statsbestmanufacturers.Admin'),
                 'dataIndex' => 'sales',
                 'width' => 60,
-                'align' => 'right',
+                'align' => 'center',
             ],
         ];
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Unifies the look of module to the same as statsbestsuppliers and removes the logo.gif usage in the html. It was the last module to look this way.
| Type?         | refacto
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Check that if you go to Stats > Best brands, it looks the same as Best suppliers. Or just check the screens below and trust me. :-)

### This module
![brands](https://user-images.githubusercontent.com/6097524/221855338-a4925eb9-59de-48ae-b3ff-0d61a97537b2.jpg)

### Suppliers
![suppliers](https://user-images.githubusercontent.com/6097524/221855340-2d5646ed-550d-4be5-9e6e-561e9464e5bb.jpg)

### Export works fine
![export](https://user-images.githubusercontent.com/6097524/221855386-ccde1718-05dc-4878-9a24-cabea3607aca.jpg)
